### PR TITLE
Lodash `pluck` fix

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -229,7 +229,7 @@ function logranktest (groupedDataTable) {
 
 var exports = {
 	init: obj => {
-		pluck = obj.pluck;
+		pluck = obj.pluck || obj.map;
 		uniq = obj.uniq;
 		sortBy = obj.sortBy;
 		groupBy = obj.groupBy;


### PR DESCRIPTION
Lodash removed `_.pluck` in version 4.x in favor of `_.map` with the iteratee shorthand. See the [changelog](https://github.com/lodash/lodash/wiki/Changelog) for more details.

Since the kaplan-meier lib requires a `pluck` method on the object passed to `init`, using modern versions of lodash fail. This is a really simple fix that maintains a preference for existing `pluck` methods.